### PR TITLE
Update tutorial-one-elixir.md

### DIFF
--- a/site/tutorials/tutorial-one-elixir.md
+++ b/site/tutorials/tutorial-one-elixir.md
@@ -65,7 +65,7 @@ digraph G {
 > end
 > defp deps() do
 >   [
->     {:amqp, "~> 1.0"},
+>     {:amqp, "~> 1.1.0"},
 >   ]
 > end
 > </pre>


### PR DESCRIPTION
AMPQ v1.0 compilation results in a command error when compiling ranch_proxy_protocol. An update in AMPQ v1.1.0 resolves this issue.